### PR TITLE
Fix elixir 1.6 issue

### DIFF
--- a/lib/alphanumeric.ex
+++ b/lib/alphanumeric.ex
@@ -41,7 +41,8 @@ defmodule Alphanumeric do
 
   def get_index(collection, param) when is_list(collection) do
     Enum.with_index(collection)
-    |> Enum.filter_map(fn {x, _} -> x == param end, fn {_, i} -> i end)
+    |> Enum.filter(fn {x, _} -> x == param end)
+    |> Enum.map(fn {_, i} -> i end)
     |> List.first
   end
 

--- a/lib/alphanumeric.ex
+++ b/lib/alphanumeric.ex
@@ -1,5 +1,5 @@
 defmodule Alphanumeric do
-  @table String.split("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", "")
+  @table String.split("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz", "", trim: true)
 
   def to_decimal_number62(number) when number > 61 do
     to_decimal_number62(div(number, 62)) <> Enum.fetch!(@table, rem(number, 62))


### PR DESCRIPTION
I fixed some issues with Elixir 1.6.

# Fix `String.split` issue

[elixir/CHANGELOG.md at v1.6 · elixir-lang/elixir](https://github.com/elixir-lang/elixir/blob/v1.6/CHANGELOG.md)
```
[String] Return a leading empty space when splitting on empty string. This makes the split operation consistent with the other operations in the String module
```

# Fix deprecation warning
```
warning: Enum.filter_map/3 is deprecated, use Enum.filter/2 + Enum.map/2 or for comprehensions
  lib/alphanumeric.ex:44
```